### PR TITLE
Update RoutesParser.cfc

### DIFF
--- a/modules/cbswagger/models/RoutesParser.cfc
+++ b/modules/cbswagger/models/RoutesParser.cfc
@@ -95,7 +95,7 @@ component accessors="true" threadsafe singleton{
 				var moduleEntryPoint = arrayToList( listToArray( moduleConfigCache[ route.module ].entrypoint, "/" ), "/" );
 				route.pattern = moduleEntryPoint & '/' & route.pattern;
 
-				if( structKeyExists( moduleConfigCache[ route.module ], "cfmapping" ) ){
+				if( structKeyExists( moduleConfigCache[ route.module ], "cfmapping" ) and len( moduleConfigCache[ route.module ].cfmapping) ){
 					route[ "moduleInvocationPath" ] = moduleConfigCache[ route.module ].cfmapping;
 				} else {
 					var moduleConventionPath = listToArray( variables.controller.getColdboxSettings().modulesConvention, "/" );


### PR DESCRIPTION
In debugging my module, I saw that the cfmapping key was defined but it was an empty string. I added a this.cfmapping to the top of my module's ModuleConfig.cfc and gave it a value, which no longer triggered the error that led me to this. 