### PR TITLE
Fix documentation on parameters doc includes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,7 @@ _Note: Because CFML has its own `parameters` key within the function metadata, w
 ```js
 /**
  * @hint Adds a new user
- * @x-parameters /includes/resources/users.add.parameters.json##user
+ * @x-parameters /includes/resources/users.add.parameters.json
  * @responses /includes/resources/users.add.responses.json
  * @x-SomeAdditionalInfo Here is some additional information on this path
  * @requestBody {

--- a/readme.md
+++ b/readme.md
@@ -198,10 +198,12 @@ function add( event, rc, prc ){
 
 *Example using JSON ( + file pointers )*
 
+_Note: Because CFML has its own `parameters` key within the function metadata, we would pull in a document of parameters using `x-parameters`, which will appear as `parameters` in the swagger method definition_
+
 ```js
 /**
  * @hint Adds a new user
- * @parameters /includes/resources/users.add.parameters.json##user
+ * @x-parameters /includes/resources/users.add.parameters.json##user
  * @responses /includes/resources/users.add.responses.json
  * @x-SomeAdditionalInfo Here is some additional information on this path
  * @requestBody {


### PR DESCRIPTION
The usage of `@parameters` in a docblock will not work because CFML metadata overwrites it with its own key of the same name.  Using the `x-` prefix will allow a full set of parameters to be pulled in.