### PR TITLE
add excludeRoutes option

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -34,7 +34,8 @@ component{
 		settings = {
 			// The route prefix to search.  Routes beginning with this prefix will be determined to be api routes
 			"routes"   : [ "api" ],
-
+			// Routes to exclude from the generated spec
+			"excludeRoutes"	: [],
 			// The default output format, either json or yml
 			"defaultFormat" : "json",
 

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -107,20 +107,20 @@ component accessors="true" threadsafe singleton{
 
 		// Now loop through our assembled module routes and append if designated
 		var moduleConfigCache 	= variables.moduleService.getModuleConfigCache();
-		var moduleSettings 		= variables.controller.getSetting( "modules" );
+		var modulesSettings 		= variables.controller.getSetting( "modules" );
 
 		for( var route in moduleSESRoutes ){
 			if(
 				// module exists
-				structKeyExists( moduleSettings, route.module )
+				structKeyExists( modulesSettings, route.module )
 				&&
 				// and it has an entry point
-				len( moduleSettings[ route.module ].entryPoint )
+				len( modulesSettings[ route.module ].entryPoint )
 			){
-				var moduleEntryPoint = moduleSettings[ route.module ].entryPoint;
+				var moduleEntryPoint = modulesSettings[ route.module ].entryPoint;
 				// Check if ColdBox 5 inherited entry points are available.
-				if( moduleSettings[ route.module ].keyExists( "inheritedEntryPoint") ){
-					moduleEntryPoint = moduleSettings[ route.module ].inheritedEntryPoint;
+				if( modulesSettings[ route.module ].keyExists( "inheritedEntryPoint") ){
+					moduleEntryPoint = modulesSettings[ route.module ].inheritedEntryPoint;
 				}
 				// TODO: not sure why Jon is doing this, ask him.
 				var moduleEntryPoint = arrayToList( listToArray( moduleEntryPoint, "/" ), "/" );

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -147,9 +147,9 @@ component accessors="true" threadsafe singleton{
 		}
 
 		// Remove any route excludes
-		if ( !!ArrayLen( variables.moduleSettings.excludeRoutes ) ) {
+		if ( !!ArrayLen( moduleSettings.excludeRoutes ) ) {
 			for ( var route in StructKeyArray( designatedRoutes ) ) {
-				if ( !!ArrayFindNoCase( variables.moduleSettings.excludeRoutes, route ) ) {
+				if ( !!ArrayFindNoCase( moduleSettings.excludeRoutes, route ) ) {
 					StructDelete( designatedRoutes, route );
 				}
 			}

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -229,7 +229,7 @@ component accessors="true" threadsafe singleton{
 	private void function addPathFromRouteConfig(
 		required any existingPaths,
 		required string pathKey,
-		required any routeConfig
+		required any routeConfig,
 		any handlerMetadata
 	){
 		var path 			= structNew( "ordered" );

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -146,6 +146,15 @@ component accessors="true" threadsafe singleton{
 
 		}
 
+		// Remove any route excludes
+		if ( !!ArrayLen( variables.moduleSettings.excludeRoutes ) ) {
+			for ( var route in StructKeyArray( designatedRoutes ) ) {
+				if ( !!ArrayFindNoCase( variables.moduleSettings.excludeRoutes, route ) ) {
+					StructDelete( designatedRoutes, route );
+				}
+			}
+		}
+
 		// Now custom sort our routes alphabetically
 		var entrySet 		= structKeyArray( designatedRoutes );
 		var sortedRoutes 	= structNew( "ordered" );

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ cbswagger = {
 	// The route prefix to search.  Routes beginning with this prefix will be determined to be api routes
 	"routes" : [ "api" ],
 	// The default output format: json or yml
+	// Any routes to exclude
+	"excludeRoutes"	: [],
 	"defaultFormat" : "json",
 	// Information about your API
 	"info"		:{
@@ -159,7 +161,7 @@ http://localhost/cbSwagger/yml
 - Parameters provided via the route ( e.g. the `id` in `/api/v1/users/:id` ) will always be included in the array of parameters as required for the method.  Annotations on those parameters may be used to provide additional documentation.
 - You may also provide paths to JSON files which describe complex objects which may not be expressed within the attributes themselves.  This is ideal to provide an endpoint for [parameters](https://swagger.io/specification/#parameterObject) and [responses](https://swagger.io/specification/#responsesObject)  If the atttribute ends with `.json`, this will be included in the generated OpenAPI document as a [$ref include](https://swagger.io/specification/#pathItemObject).
 - Attributes which are not part of the swagger path specification should be prefixed with an `x-`, [x-attributes](https://swagger.io/specification/#specificationExtensions) are an official part of the OpenAPI Specification and may be used to provide additional information for your developers and consumers
-- `hint` attributes, provided as either comment `@` annotations or as function body attributes will be treaded as the description for the method 
+- `hint` attributes, provided as either comment `@` annotations or as function body attributes will be treaded as the description for the method
 - `description` due to variances in parsing comment annotations, `description` annotations must be provided as attributes of the function body.  For example, you would use `function update( event, rc, prc ) description="Updates a user"{}` rather than `@description Updates a user`
 
 *Basic Example:*


### PR DESCRIPTION
Add an option `excludeRoutes` to the config to exclude certain routes from appearing in the generated API spec