### PR TITLE
Add security annotation

### DIFF
--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -463,6 +463,25 @@ component accessors="true" threadsafe singleton{
 					continue;
 				}
 
+				// security
+				if ( infoKey == "security" ) {
+					method.put( "security", [] );
+					if ( IsSimpleValue( infoMetadata ) ) {
+						// expect a list of pre-defined securitySchemes
+						for ( var security in ListToArray( infoMetadata, " " ) ) {
+							if ( StructKeyList( moduleSettings.components.securitySchemes ).find( security ) ) {
+								var secStruct = {};
+								secStruct[ security ] = [];
+								method[ "security" ].append( secStruct );
+							}
+						}
+					}
+					else {
+						method[ "security" ] = infoMetadata;
+					}
+					continue;
+				}
+
 				// Spec Extensions x-{name}, must be in lowercase
 				if( left( infoKey, 2 ) == "x-" ){
 					var normalizedKey = replaceNoCase( infoKey, "x-", "" ).lcase();
@@ -522,7 +541,7 @@ component accessors="true" threadsafe singleton{
 			} else {
 				var filterString = arrayToList( [ handlerMetadata.name, methodName ], "." );
 			}
-			
+
 			availableFiles.filter( function( filePath ){
 				return findNoCase( filterString, replaceNoCase( filePath, conventionDirectory, "" ) );
 			} )
@@ -553,11 +572,11 @@ component accessors="true" threadsafe singleton{
 	){
 		functionMetadata
 			.keyArray()
-			.filter( 
+			.filter(
 				function( key ){
 					return left( key, 6 ) == 'param-';
-				} 
-			).each( 
+				}
+			).each(
 				function( infoKey ){
 					// parse values from each key
 					var infoMetadata = parseMetadataValue( functionMetaData[ infoKey ] );
@@ -602,9 +621,9 @@ component accessors="true" threadsafe singleton{
 							parameter
 						);
 					}
-				} 
+				}
 			);
-			
+
 		sampleArgs = { "type" : "parameters" };
 		sampleArgs.append( arguments );
 		appendConventionSamples( argumentCollection=sampleArgs );
@@ -620,11 +639,11 @@ component accessors="true" threadsafe singleton{
 	){
 		functionMetadata
 			.keyArray()
-			.filter( 
+			.filter(
 				function( key ){
 					return left( key, 9 ) == 'response-';
-				} 
-			).each( 
+				}
+			).each(
 				function( infoKey ){
 					// parse values from each key
 					var infoMetadata = parseMetadataValue( functionMetaData[ infoKey ] );
@@ -643,7 +662,7 @@ component accessors="true" threadsafe singleton{
 						method[ "responses" ][ responseName ].putAll( infoMetadata );
 					}
 
-				} 
+				}
 			);
 
 			sampleArgs = { "type" : "responses" };

--- a/readme.md
+++ b/readme.md
@@ -126,10 +126,9 @@ cbswagger = {
 		}
 	},
 
-	// A declaration of which security mechanisms can be used across the API.
-	// The list of values includes alternative security requirement objects that can be used.
+	// A default security declaration to be used across the API.
 	// Only one of the security requirement objects need to be satisfied to authorize a request.
-	// Individual operations can override this definition.
+	// Individual operations can override this definition with `@security`
 	"security" : [
 		{ "APIKey" : [] },
 		{ "UserSecurity" : [] }
@@ -161,6 +160,7 @@ http://localhost/cbSwagger/yml
 - Metadata attributes using a `response-` prefix in the annotation will be parsed as responses.   For example `@response-200 { "description" : "User successfully updated", "schema" : "/includes/resources/schema.json##user" }` would populate the `200` responses node for the given method ( in this case, `PUT /api/v1/users/:id` ). If the annotation text is not valid JSON or a file pointer, this will be provided as the response description.
 - Metadata attributes prefixed with `param-` will be included as paramters to the method/action.  Example: `@param-firstname { "type": "string", "required" : "false", "in" : "query" }` If the annotation text is not valid JSON or a file pointer, this will be provided as the parameter description and the parameter requirement will be set to `false`.
 - Parameters provided via the route ( e.g. the `id` in `/api/v1/users/:id` ) will always be included in the array of parameters as required for the method.  Annotations on those parameters may be used to provide additional documentation.
+- Security nodes defined in the cbSwagger config will be displayed on every API method, except methods that override the default with `@security`. You may use the name of a security scheme, a JSON array of security nodes, or a file pointer. All security nodes must have the same name as a security scheme defined under components or they will be ignored.
 - You may also provide paths to JSON files which describe complex objects which may not be expressed within the attributes themselves.  This is ideal to provide an endpoint for [parameters](https://swagger.io/specification/#parameterObject) and [responses](https://swagger.io/specification/#responsesObject)  If the atttribute ends with `.json`, this will be included in the generated OpenAPI document as a [$ref include](https://swagger.io/specification/#pathItemObject).
 - Attributes which are not part of the swagger path specification should be prefixed with an `x-`, [x-attributes](https://swagger.io/specification/#specificationExtensions) are an official part of the OpenAPI Specification and may be used to provide additional information for your developers and consumers
 - `hint` attributes, provided as either comment `@` annotations or as function body attributes will be treaded as the description for the method
@@ -175,6 +175,7 @@ function add( event, rc, prc )
 	description="Adds a new user"
 	parameters="/includes/resources/users.add.parameters.json"
 	responses="/includes/resources/users.add.responses.json"
+	security="APIKey"
 	x-SomeAdditionalInfo="Here is some additional information on this path"
 {
 
@@ -208,6 +209,7 @@ function add( event, rc, prc ){
  * @parameters /includes/resources/users.add.parameters.json##user
  * @responses /includes/resources/users.add.responses.json
  * @x-SomeAdditionalInfo Here is some additional information on this path
+ * @security /includes/resources/users.add.security.json
  * @requestBody {
  * 	"description" : "User to add",
  * 	"required" : true,
@@ -226,6 +228,7 @@ function add( event, rc, prc ){
  * @param-firstname { "schema" : { "type": "string" }, "required" : "false", "in" : "query" }
  * @param-lastname { "schema" : { "type": "string" }, "required" : "false", "in" : "query" }
  * @param-email { "schema" : { "type": "string" }, "required" : "false", "in" : "query" }
+ * @security [ { "APIKey": [] } ]
  * @response-default { "description" : "User successfully updated", "content" : { "application/json" : { "schema" : { "$ref" : "/includes/resources/schema.json##user" } } } }
  */
 function update( event, rc, prc ) description="Updates a user"{

--- a/readme.md
+++ b/readme.md
@@ -126,9 +126,10 @@ cbswagger = {
 		}
 	},
 
-	// A default security declaration to be used across the API.
-	// Only one of the security requirement objects need to be satisfied to authorize a request.
-	// Individual operations can override this definition with `@security`
+	// A default declaration of Security Requirement Objects to be used across the API.
+	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securityRequirementObject
+	// Only one of these requirements needs to be satisfied to authorize a request.
+	// Individual operations may set their own requirements with `@security`
 	"security" : [
 		{ "APIKey" : [] },
 		{ "UserSecurity" : [] }
@@ -160,7 +161,7 @@ http://localhost/cbSwagger/yml
 - Metadata attributes using a `response-` prefix in the annotation will be parsed as responses.   For example `@response-200 { "description" : "User successfully updated", "schema" : "/includes/resources/schema.json##user" }` would populate the `200` responses node for the given method ( in this case, `PUT /api/v1/users/:id` ). If the annotation text is not valid JSON or a file pointer, this will be provided as the response description.
 - Metadata attributes prefixed with `param-` will be included as paramters to the method/action.  Example: `@param-firstname { "type": "string", "required" : "false", "in" : "query" }` If the annotation text is not valid JSON or a file pointer, this will be provided as the parameter description and the parameter requirement will be set to `false`.
 - Parameters provided via the route ( e.g. the `id` in `/api/v1/users/:id` ) will always be included in the array of parameters as required for the method.  Annotations on those parameters may be used to provide additional documentation.
-- Security nodes defined in the cbSwagger config will be displayed on every API method, except methods that override the default with `@security`. You may use the name of a security scheme, a JSON array of security nodes, or a file pointer. All security nodes must have the same name as a security scheme defined under components or they will be ignored.
+- [Security Requirement Objects](https://swagger.io/specification/#securityRequirementObject) defined in the cbSwagger config will be displayed on every API method, except methods that override the default with `@security`. You may use the name of a security scheme, a JSON array of Security Requirement Objects, or a file pointer. Security Requirement Objects must have the same name as a Security Scheme Object defined under components in `cbSwagger` settings.
 - You may also provide paths to JSON files which describe complex objects which may not be expressed within the attributes themselves.  This is ideal to provide an endpoint for [parameters](https://swagger.io/specification/#parameterObject) and [responses](https://swagger.io/specification/#responsesObject)  If the atttribute ends with `.json`, this will be included in the generated OpenAPI document as a [$ref include](https://swagger.io/specification/#pathItemObject).
 - Attributes which are not part of the swagger path specification should be prefixed with an `x-`, [x-attributes](https://swagger.io/specification/#specificationExtensions) are an official part of the OpenAPI Specification and may be used to provide additional information for your developers and consumers
 - `hint` attributes, provided as either comment `@` annotations or as function body attributes will be treaded as the description for the method


### PR DESCRIPTION
Allow `@security` annotation to override the security mechanisms defined in config. The value can be a JSON array of security directives, a file pointer, or for convenience the name of a security schema.