### PR TITLE
Add CORS support for cbswagger endpoint

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -85,10 +85,17 @@ component {
 		};
 
 		// SES Routes
-		router
-			.route( "/", "main.index" )
-			.route( "/json", "main.json" )
-			.route( "/yml", "main.yml" );
+		router.route( "/" )
+			.withHandler( "Main" )
+			.toAction( { "GET": "index", "OPTIONS": "options" } );
+
+		router.route( "/json" )
+			.withHandler( "Main" )
+			.toAction( { "GET": "json", "OPTIONS": "options" } );
+
+		router.route( "/yml" )
+			.withHandler( "Main" )
+			.toAction( { "GET": "yml", "OPTIONS": "options" } );
 	}
 
 	/**

--- a/handlers/Main.cfc
+++ b/handlers/Main.cfc
@@ -26,6 +26,32 @@ component extends="coldbox.system.EventHandler" {
 		param name     ="rc.format" default="#variables.settings.defaultFormat#";
 		// Build out document
 		prc.apiDocument = routesParser.createDocFromRoutes();
+
+		// Shared CORS headers
+		event.setHTTPHeader(
+			name = "Access-Control-Allow-Origin",
+			value = event.getHTTPHeader( "Origin", "*" )
+		);
+		event.setHTTPHeader(
+			name = "Access-Control-Allow-Credentials",
+			value = true
+		);
+	}
+
+	function options( event, rc, prc ) {
+		event.setHTTPHeader(
+			name = "Access-Control-Allow-Headers",
+			value = event.getHTTPHeader( "Access-Control-Request-Headers", "" )
+		);
+		event.setHTTPHeader(
+			name = "Access-Control-Allow-Methods",
+			value = event.getHTTPHeader( "Access-Control-Request-Method", event.getHTTPMethod() )
+		);
+		event.setHTTPHeader(
+			name = "Access-Control-Max-Age",
+			value = 60 * 60 * 24 // 1 day
+		);
+		event.renderData( "plain", "Preflight OK" );
 	}
 
 	/**


### PR DESCRIPTION
We occasionally point a Swagger Document Viewer at the `/cbswagger` endpoint.  Since this crosses domains, it needs to have the correct CORS endpoints.  This PR adds those.