### PR TITLE
Remove empty external docs object

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -78,10 +78,7 @@ component {
 			"security"     : [],
 			// A list of tags used by the specification with additional metadata.
 			// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#tagObject
-			"tags"         : [],
-			// Additional external documentation.
-			// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#externalDocumentationObject
-			"externalDocs" : { "description" : "", "url" : "" }
+			"tags"         : []
 		};
 
 		// SES Routes

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,13 @@ cbswagger = {
 			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
 		},
 		//The version of your API
-		"version":"1.0.0"
+		"version":"1.0.0",
+
+		// https://swagger.io/specification/#externalDocumentationObject
+		"externalDocs" : {
+			"description": "Find more info here",
+			"url": "https://blog.readme.io/an-example-filled-guide-to-swagger-3-2/"
+		}
 	},
 
 	// Tags
@@ -83,12 +89,6 @@ cbswagger = {
 			"description": "Pets operations"
 		}
 	],
-
-	// https://swagger.io/specification/#externalDocumentationObject
-	"externalDocs" : {
-		"description": "Find more info here",
-		"url": "https://blog.readme.io/an-example-filled-guide-to-swagger-3-2/"
-	},
 
 	// https://swagger.io/specification/#serverObject
 	"servers" : [

--- a/test-harness/config/Coldbox.cfc
+++ b/test-harness/config/Coldbox.cfc
@@ -96,7 +96,13 @@
 						"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
 					},
 					//The version of your API
-					"version":"1.0.0"
+					"version":"1.0.0",
+
+					// https://swagger.io/specification/#externalDocumentationObject
+					"externalDocs" : {
+						"description": "Find more info here",
+						"url": "https://blog.readme.io/an-example-filled-guide-to-swagger-3-2/"
+					}
 				},
 
 				// Tags
@@ -106,12 +112,6 @@
 						"description": "Pets operations"
 					}
 				],
-
-				// https://swagger.io/specification/#externalDocumentationObject
-				"externalDocs" : {
-					"description": "Find more info here",
-					"url": "https://blog.readme.io/an-example-filled-guide-to-swagger-3-2/"
-				},
 
 				// https://swagger.io/specification/#serverObject
 				"servers" : [

--- a/test-harness/tests/specs/RoutesParserTest.cfc
+++ b/test-harness/tests/specs/RoutesParserTest.cfc
@@ -77,8 +77,7 @@ component
 					.toHaveKey( "paths" )
 					.toHaveKey( "components" )
 					.toHaveKey( "security" )
-					.toHaveKey( "tags" )
-					.toHaveKey( "externalDocs" );
+					.toHaveKey( "tags" );
 
 				expect( isJSON( APIDoc.asJSON() ) ).toBeTrue();
 


### PR DESCRIPTION
**This PR depends on https://github.com/coldbox-modules/swagger-sdk/pull/10 being merged and published.**

Many validation and linting tools do not allow empty strings as valid urls or descriptions.  Additionally, `externalDocs` is hardly
used.  Users may add it back in if they would like, but the default will be to omit it.