### PR TITLE
account for COLDBOX_APP_MAPPING (using subfolder)

### DIFF
--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -47,6 +47,7 @@ component accessors="true" threadsafe singleton {
 		}
 		variables.SESRoutes = variables.routingService.getRoutes();
 		variables.util      = new coldbox.system.core.util.Util();
+		variables.appMapping = getAppMapping();
 	}
 
 	/**
@@ -119,10 +120,10 @@ component accessors="true" threadsafe singleton {
 				// and it has an entry point
 				len( modulesSettings[ route.module ].entryPoint )
 			) {
-				var moduleEntryPoint = modulesSettings[ route.module ].entryPoint;
+				var moduleEntryPoint = variables.appMapping & modulesSettings[ route.module ].entryPoint;
 				// Check if ColdBox 5 inherited entry points are available.
 				if ( modulesSettings[ route.module ].keyExists( "inheritedEntryPoint" ) ) {
-					moduleEntryPoint = modulesSettings[ route.module ].inheritedEntryPoint;
+					moduleEntryPoint = variables.appMapping & modulesSettings[ route.module ].inheritedEntryPoint;
 				}
 				// TODO: not sure why Jon is doing this, ask him.
 				var moduleEntryPoint = arrayToList(
@@ -849,4 +850,10 @@ component accessors="true" threadsafe singleton {
 		return;
 	}
 
+	private string function getAppMapping() {
+		var appMapping = variables.controller.getSetting("appMapping");
+		if(!len(trim(appMapping))) return "";
+
+		return appMapping & "/";
+	}
 }


### PR DESCRIPTION
I spent a while trying to figure out if there's a setting in coldbox or cbswagger to add the path of the coldbox app to the route. my setup is like this
```
/ (main web app -- not using coldbox here)
/api (coldbox is here)
/api/modules_app/example (ModuleConfig.cfc has this.entryPoint = "example")
/api/modules_app/healthcheck (ModuleConfig.cfc has this.entryPoint = "healthcheck")
```
with the cbSwagger module I'm expecting the json to say my routes start with /api, e.g.
```
/api/example
/api/healthcheck
```
but cbSwagger says my routes are
```
/example
/healthcheck
```
I've looked at the module settings for inheritEntryPoint, entryPoint, and COLDBOX_APP_MAPPING in the main Application.cfc and I saw no way to inherit those for every module without modules { } hardcoding in coldbox.cfc.

Please let me know if there's a better way to do this. I think this may be an inferior approach because it does not account for URL Rewrites.