### PR TITLE
Exclude routes by prefix

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -25,6 +25,8 @@ component {
 		settings = {
 			// The route prefix to search.  Routes beginning with this prefix will be determined to be api routes
 			"routes"        : [ "api" ],
+			// Routes to exclude by prefix.  Routes beginning with this prefix will be excluded
+			"excludeRoutesPrefix" : [],
 			// Routes to exclude from the generated spec
 			"excludeRoutes" : [],
 			// The default output format, either json or yml

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -159,7 +159,7 @@ component accessors="true" threadsafe singleton {
 		}
 
 		// Remove any route excludes by prefix
-		if ( !!arrayLen( moduleSettings.excludeRoutesPrefix ) ) {
+		if ( arrayLen( moduleSettings.excludeRoutesPrefix ) ) {
 			for ( var excludePrefix in moduleSettings.excludeRoutesPrefix ) {
 				for ( var currentRoute in structKeyArray( designatedRoutes ) ) {
 					if ( left( designatedRoutes[ currentRoute ].pattern, len( excludePrefix ) ) == excludePrefix ) {

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -158,6 +158,17 @@ component accessors="true" threadsafe singleton {
 			}
 		}
 
+		// Remove any route excludes by prefix
+		if ( !!arrayLen( moduleSettings.excludeRoutesPrefix ) ) {
+			for ( var excludePrefix in moduleSettings.excludeRoutesPrefix ) {
+				for ( var currentRoute in structKeyArray( designatedRoutes ) ) {
+					if ( left( designatedRoutes[ currentRoute ].pattern, len( excludePrefix ) ) == excludePrefix ) {
+						structDelete( designatedRoutes, currentRoute );
+					}
+				}
+			}
+		}
+
 		// Remove any route excludes
 		if ( !!arrayLen( moduleSettings.excludeRoutes ) ) {
 			for ( var route in structKeyArray( designatedRoutes ) ) {

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ cbswagger = {
 	// The route prefix to search.  Routes beginning with this prefix will be determined to be api routes
 	"routes" : [ "api" ],
 	// The default output format: json or yml
+	// Routes to exclude by prefix.  Routes beginning with this prefix will be excluded
+	"excludeRoutesPrefix" : [ "cbswagger", "relax" ],
 	// Any routes to exclude
 	"excludeRoutes"	: [],
 	"defaultFormat" : "json",
@@ -155,7 +157,7 @@ http://localhost/cbSwagger/yml
 
 ## Handler Introspection & Documentation attributes
 
-`cbSwagger` will automatically introspect your API handlers provided by your routing configuration.  You may provide additional function attributes (**metadata**), which will be picked up and included in your documentation.  
+`cbSwagger` will automatically introspect your API handlers provided by your routing configuration.  You may provide additional function attributes (**metadata**), which will be picked up and included in your documentation.
 
 The content body of these function metadata/attributes may be provided as:
 
@@ -166,12 +168,12 @@ The content body of these function metadata/attributes may be provided as:
 Here are some additional pointers for you:
 
 - Metadata attributes using a `response-` prefix in the annotation will be parsed as responses.   For example `@response-200 { "description" : "User successfully updated", "schema" : "/resources/apidocs/schema.json##user" }` would populate the `200` responses node for the given method ( in this case, `PUT /api/v1/users/:id` ). If the annotation text is not valid JSON or a file pointer, this will be provided as the response description.
-- Metadata attributes prefixed with `param-` will be included as paramters to the method/action.  Example: `@param-firstname { "type": "string", "required" : "false", "in" : "query" }` If the annotation text is not valid JSON or a file pointer, this will be provided as the parameter description and the parameter requirement will be set to `false`.
+- Metadata attributes prefixed with `param-` will be included as parameters to the method/action.  Example: `@param-firstname { "type": "string", "required" : "false", "in" : "query" }` If the annotation text is not valid JSON or a file pointer, this will be provided as the parameter description and the parameter requirement will be set to `false`.
 - Parameters provided via the route ( e.g. the `id` in `/api/v1/users/:id` ) will always be included in the array of parameters as required for the method.  Annotations on those parameters may be used to provide additional documentation.
 - [Security Requirement Objects](https://swagger.io/specification/#securityRequirementObject) defined in the cbSwagger config will be displayed on every API method, except methods that override the default with `@security`. You may use the name of a security scheme, a JSON array of Security Requirement Objects, or a file pointer. Security Requirement Objects must have the same name as a Security Scheme Object defined under components in `cbSwagger` settings.
 - You may also provide paths to JSON files which describe complex objects which may not be expressed within the attributes themselves.  This is ideal to provide an endpoint for [parameters](https://swagger.io/specification/#parameterObject) and [responses](https://swagger.io/specification/#responsesObject)  If the atttribute ends with `.json`, this will be included in the generated OpenAPI document as a [$ref include](https://swagger.io/specification/#pathItemObject).
 - Attributes which are not part of the swagger path specification should be prefixed with an `x-`, [x-attributes](https://swagger.io/specification/#specificationExtensions) are an official part of the OpenAPI Specification and may be used to provide additional information for your developers and consumers
-- `hint` attributes, provided as either comment `@` annotations or as function body attributes will be treaded as the description for the method
+- `hint` attributes, provided as either comment `@` annotations or as function body attributes will be treated as the description for the method
 - `description` due to variances in parsing comment annotations, `description` annotations must be provided as attributes of the function body.  For example, you would use `function update( event, rc, prc ) description="Updates a user"{}` rather than `@description Updates a user`
 - `tags` : A list of tags to include in the operation metadata: `@tags Authentication,Authors`.
 
@@ -180,7 +182,7 @@ Here are some additional pointers for you:
 ```js
 /**
  * Add a new user into the system
- * 
+ *
  * @tags Users,Authentication
  */
 function add( event, rc, prc )


### PR DESCRIPTION
Specifying a prefix will exclude that matching path. I also fixed a couple of small typos in readme.md.