### PR TITLE
Separate summary and description

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -7,16 +7,16 @@
 component {
 
 	// Module Properties
-	this.title              = "cbswagger";
-	this.author             = "Jon Clausen <jon_clausen@silowebworks.com>";
-	this.webURL             = "https://github.com/coldbox-modules/cbSwagger";
-	this.version            = "@version.number@+@build.number@";
-	this.description        = "A coldbox module to auto-generate Swagger API documentation from your configured routes";
-	this.entryPoint         = "cbswagger";
-	this.modelNamespace     = "cbswagger";
-	this.cfmapping          = "cbswagger";
-	this.autoMapModels      = true;
-	this.dependencies       = [ "swagger-sdk" ];
+	this.title          = "cbswagger";
+	this.author         = "Jon Clausen <jon_clausen@silowebworks.com>";
+	this.webURL         = "https://github.com/coldbox-modules/cbSwagger";
+	this.version        = "@version.number@+@build.number@";
+	this.description    = "A coldbox module to auto-generate Swagger API documentation from your configured routes";
+	this.entryPoint     = "cbswagger";
+	this.modelNamespace = "cbswagger";
+	this.cfmapping      = "cbswagger";
+	this.autoMapModels  = true;
+	this.dependencies   = [ "swagger-sdk" ];
 
 	/**
 	 * Configure module
@@ -24,18 +24,18 @@ component {
 	function configure(){
 		settings = {
 			// The route prefix to search.  Routes beginning with this prefix will be determined to be api routes
-			"routes"        : [ "api" ],
+			"routes"              : [ "api" ],
 			// Routes to exclude by prefix.  Routes beginning with this prefix will be excluded
 			"excludeRoutesPrefix" : [],
 			// Routes to exclude from the generated spec
-			"excludeRoutes" : [],
+			"excludeRoutes"       : [],
 			// The default output format, either json or yml
-			"defaultFormat" : "json",
+			"defaultFormat"       : "json",
 			// A convention route, relative to your app root, where request/response samples are stored ( e.g. resources/apidocs/responses/[module].[handler].[action].[HTTP Status Code].json )
-			"samplesPath"   : "resources/apidocs",
+			"samplesPath"         : "resources/apidocs",
 			// Information about your API
 			// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#infoObject
-			"info"          : {
+			"info"                : {
 				// REQUIRED A title for your API
 				"title"          : "My Awesome API",
 				// A short description of the application. CommonMark syntax MAY be used for rich text representation.
@@ -63,30 +63,39 @@ component {
 			},
 			// An array of Server Objects, which provide connectivity information to a target server. If the servers property is not provided, or is an empty array, the default value would be a Server Object with a url value of /.
 			// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#serverObject
-			"servers"      : [],
+			"servers"    : [],
 			// An element to hold various schemas for the specification.
 			// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject
-			"components"   : {},
+			"components" : {},
 			// A declaration of which security mechanisms can be used across the API.
 			// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securityRequirementObject
-			"security"     : [],
+			"security"   : [],
 			// A list of tags used by the specification with additional metadata.
 			// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#tagObject
-			"tags"         : []
+			"tags"       : []
 		};
 
 		// SES Routes
-		router.route( "/" )
+		router
+			.route( "/" )
 			.withHandler( "Main" )
-			.toAction( { "GET": "index", "OPTIONS": "options" } );
+			.toAction( {
+				"GET"     : "index",
+				"OPTIONS" : "options"
+			} );
 
-		router.route( "/json" )
+		router
+			.route( "/json" )
 			.withHandler( "Main" )
-			.toAction( { "GET": "json", "OPTIONS": "options" } );
+			.toAction( {
+				"GET"     : "json",
+				"OPTIONS" : "options"
+			} );
 
-		router.route( "/yml" )
+		router
+			.route( "/yml" )
 			.withHandler( "Main" )
-			.toAction( { "GET": "yml", "OPTIONS": "options" } );
+			.toAction( { "GET" : "yml", "OPTIONS" : "options" } );
 	}
 
 	/**

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -536,16 +536,33 @@ component accessors="true" threadsafe singleton {
 					// parse values from each key
 					var infoMetadata = parseMetadataValue( functionMetaData[ infoKey ] );
 
-					// hint/description/summary
+					// hint/description
 					if ( infoKey == "hint" ) {
+						if ( !method.containsKey( "description" ) || method[ "description" ] == "" ) {
+							method.put( "description", infoMetadata );
+						}
+						if ( !functionMetadata.containsKey( "summary" ) ) {
+							method.put( "summary", infoMetadata );
+						}
+						continue;
+					}
+
+					if ( infoKey == "description" && infoMetadata != "" ) {
 						method.put( "description", infoMetadata );
+						continue;
+					}
+
+					if ( infoKey == "summary" ) {
 						method.put( "summary", infoMetadata );
 						continue;
 					}
 
 					// Operation Tags
 					if ( infoKey == "tags" ) {
-						method.put( "tags", ( isSimpleValue( infoMetadata ) ? listToArray( infoMetadata ) : infoMetadata ) );
+						method.put(
+							"tags",
+							( isSimpleValue( infoMetadata ) ? listToArray( infoMetadata ) : infoMetadata )
+						);
 						continue;
 					}
 

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -162,7 +162,12 @@ component accessors="true" threadsafe singleton {
 		if ( arrayLen( moduleSettings.excludeRoutesPrefix ) ) {
 			for ( var excludePrefix in moduleSettings.excludeRoutesPrefix ) {
 				for ( var currentRoute in structKeyArray( designatedRoutes ) ) {
-					if ( left( designatedRoutes[ currentRoute ].pattern, len( excludePrefix ) ) == excludePrefix ) {
+					if (
+						left(
+							designatedRoutes[ currentRoute ].pattern,
+							len( excludePrefix )
+						) == excludePrefix
+					) {
 						structDelete( designatedRoutes, currentRoute );
 					}
 				}

--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -516,6 +516,7 @@ component accessors="true" threadsafe singleton {
 		); // Name
 
 		arguments.method[ "x-coldbox-operation" ] = operationPath & "." & arguments.functionName;
+		arguments.method[ "operationId" ]         = arguments.method[ "x-coldbox-operation" ];
 		arguments.functionMetaData                = getFunctionMetaData(
 			arguments.functionName,
 			arguments.handlerMetadata

--- a/test-harness/config/Routes.cfm
+++ b/test-harness/config/Routes.cfm
@@ -44,6 +44,12 @@
 	);
 
 	addRoute(
+		pattern='/api/v1/users/:id/roles',
+		handler='api.v1.Users',
+		action={"GET":"roles"}
+	);
+
+	addRoute(
 		pattern='/api/v1/users/:id',
 		handler='api.v1.Users',
 		action=defaultEntityActions

--- a/test-harness/handlers/api/v1/Users.cfc
+++ b/test-harness/handlers/api/v1/Users.cfc
@@ -62,7 +62,11 @@ component displayname="API.v1.Users" {
 	function delete( event, rc, prc ) {
 	}
 
-	// (GET) /api/v1/users/roles
+	/**
+	 * @route /api/v1/users/:id/roles
+	 * @summary Retrieves the roles for a user.
+	 * A longer description here for retrieving the roles for a user.
+	 */
 	function roles( event, rc, prc ) {
 	}
 

--- a/test-harness/handlers/api/v1/Users.cfc
+++ b/test-harness/handlers/api/v1/Users.cfc
@@ -65,7 +65,7 @@ component displayname="API.v1.Users" {
 	/**
 	 * @route /api/v1/users/:id/roles
 	 * @summary Retrieves the roles for a user.
-	 * A longer description here for retrieving the roles for a user.
+	 * @hint A longer description here for retrieving the roles for a user.
 	 */
 	function roles( event, rc, prc ) {
 	}

--- a/test-harness/tests/specs/RoutesParserTest.cfc
+++ b/test-harness/tests/specs/RoutesParserTest.cfc
@@ -241,7 +241,6 @@ component
 				expect( firstNameSearch[ 1 ].required ).toBe( false );
 			} );
 
-
 			it( "Tests the ability to parse response metadata definitions", function(){
 				expect( variables ).toHaveKey(
 					"APIDoc",
@@ -266,6 +265,52 @@ component
 				expect( path[ "put" ][ "responses" ][ "default" ][ "description" ] ).toBe( "User successfully updated" );
 
 				expect( path[ "put" ][ "responses" ][ "default" ][ "content" ] ).toBeStruct();
+			} );
+
+			it( "Tests the ability to parse summary and description metadata definitions", function(){
+				expect( variables ).toHaveKey(
+					"APIDoc",
+					"No APIDoc was found to test.  Could not continue."
+				);
+
+				var normalizedDoc = variables.APIDoc.getNormalizedDocument();
+
+				expect( normalizedDoc ).toHaveKey( "paths" );
+				expect( normalizedDoc[ "paths" ] ).toHaveKey( "/api/v1/users/{id}/roles" );
+
+				var path = normalizedDoc[ "paths" ][ "/api/v1/users/{id}/roles" ];
+
+				expect( path ).toHaveKey( "get" );
+
+				expect( path[ "get" ] ).toHaveKey( "summary" );
+				expect( path[ "get" ][ "summary" ] ).toBe( "Retrieves the roles for a user." );
+
+				expect( path[ "get" ] ).toHaveKey( "description" );
+				expect( path[ "get" ][ "description" ] ).toBe(
+					"A longer description here for retrieving the roles for a user."
+				);
+			} );
+
+			it( "Tests the ability to parse operationId metadata definitions", function(){
+				expect( variables ).toHaveKey(
+					"APIDoc",
+					"No APIDoc was found to test.  Could not continue."
+				);
+
+				var normalizedDoc = variables.APIDoc.getNormalizedDocument();
+
+				expect( normalizedDoc ).toHaveKey( "paths" );
+				expect( normalizedDoc[ "paths" ] ).toHaveKey( "/api/v1/users/{id}/roles" );
+
+				var path = normalizedDoc[ "paths" ][ "/api/v1/users/{id}/roles" ];
+
+				expect( path ).toHaveKey( "get" );
+
+				expect( path[ "get" ] ).toHaveKey( "operationId" );
+				expect( path[ "get" ][ "operationId" ] ).toBe( "API.v1.Users.roles" );
+
+				expect( path[ "get" ] ).toHaveKey( "x-coldbox-operation" );
+				expect( path[ "get" ][ "x-coldbox-operation" ] ).toBe( "API.v1.Users.roles" );
 			} );
 
 			it( "Verifies that path typing parameters are removed and that the key omits the type", function(){


### PR DESCRIPTION
Allows a `@summary` annotation to specify the summary for a `path`/endpoint.
Also sets `operationId` equal to `x-coldbox-operation`.