### PR TITLE
Add default operationId based on method name

### DIFF
--- a/models/RoutesParser.cfc
+++ b/models/RoutesParser.cfc
@@ -541,6 +541,11 @@ component accessors="true" threadsafe singleton {
 			appendFunctionParams( argumentCollection = arguments );
 			appendFunctionResponses( argumentCollection = arguments );
 
+            // Default Operation Id
+            if ( !functionMetadata.keyExists( "operationId" ) ) {
+                functionMetadata[ "operationId" ] = functionMetadata.name;
+            }
+
 			functionMetadata
 				.keyArray()
 				.each( function( infoKey ){


### PR DESCRIPTION
If the metadata @operationId isn't passed, cbSwagger will default to the handler method name.  The operationId is often used by UI components for creating anchor links.