### PR TITLE
support a per-function `@noCbSwagger` attribute

### DIFF
--- a/test-harness/config/Router.cfc
+++ b/test-harness/config/Router.cfc
@@ -54,6 +54,24 @@ component{
 			action=defaultAPIActions
 		);
 
+		// Would be included in docs, but function def has @noCbSwagger attribute
+		addRoute(
+			pattern='/api/v1/noCbSwagger',
+			handler='api.v1.Users',
+			action={
+				"GET": "sharedRouteDifferentHTTPMethods_get_shouldNotBeExposed",
+				"POST": "sharedRouteDifferentHTTPMethods_post_shouldBeExposed"
+			}
+		);
+
+		addRoute(
+			pattern='/api/v1/noCbSwagger2',
+			handler='api.v1.Users',
+			action = {
+				"GET": "loneRoute_get_shouldNotBeExposed"
+			}
+		);
+
 		// @app_routes@
 
 		// Conventions-Based Routing

--- a/test-harness/handlers/api/v1/Users.cfc
+++ b/test-harness/handlers/api/v1/Users.cfc
@@ -79,13 +79,13 @@ component displayname="API.v1.Users" {
 	}
 
 	/**
-	* @noCbSwagger
+	* @cbSwagger false
 	*/
 	function sharedRouteDifferentHTTPMethods_get_shouldNotBeExposed() {}
 	function sharedRouteDifferentHTTPMethods_post_shouldBeExposed() {}
 
 	/**
-	* @noCbSwagger
+	* @cbSwagger false
 	*/
 	function loneRoute_get_shouldNotBeExposed() {}
 

--- a/test-harness/handlers/api/v1/Users.cfc
+++ b/test-harness/handlers/api/v1/Users.cfc
@@ -78,4 +78,15 @@ component displayname="API.v1.Users" {
 		};
 	}
 
+	/**
+	* @noCbSwagger
+	*/
+	function sharedRouteDifferentHTTPMethods_get_shouldNotBeExposed() {}
+	function sharedRouteDifferentHTTPMethods_post_shouldBeExposed() {}
+
+	/**
+	* @noCbSwagger
+	*/
+	function loneRoute_get_shouldNotBeExposed() {}
+
 }

--- a/test-harness/tests/specs/RoutesParserTest.cfc
+++ b/test-harness/tests/specs/RoutesParserTest.cfc
@@ -80,9 +80,9 @@ component
 
 				expect( isJSON( APIDoc.asJSON() ) ).toBeTrue();
 
-				expect( NormalizedDoc.paths["/api/v1/noCbSwagger"] ).toHaveKey( "post", "post function NOT marked noCbSwagger" );
-				expect( NormalizedDoc.paths["/api/v1/noCbSwagger"] ).notToHaveKey( "get", "get function was marked noCbSwagger" );
-				expect( NormalizedDoc.paths ).notToHaveKey( "/api/v1/noCbSwagger2", "the lone function handling this was marked noCbSwagger" );
+				expect( NormalizedDoc.paths["/api/v1/noCbSwagger"] ).toHaveKey( "post", "post function marked cbSwagger=false" );
+				expect( NormalizedDoc.paths["/api/v1/noCbSwagger"] ).notToHaveKey( "get", "get function was not marked cbSwagger=false" );
+				expect( NormalizedDoc.paths ).notToHaveKey( "/api/v1/noCbSwagger2", "the lone function handling this was marked cbSwagger=false" );
 
 				variables.APIDoc = APIDoc;
 			} );
@@ -132,16 +132,20 @@ component
 
 				expect( arrayLen( CBRoutes ) ).toBeGT( 0 );
 
+				// in cases where we are testing that some route does not end up in the docs,
+				// we want to ensure we DO see that the route exists, and consequently that its absence from the docs
+				// is due to an intentional exclusion of a route that positively exists. 
+				var requireTheseRoutesExistWithoutDocs = {"/api/v1/noCbSwagger2": 1}
+
 				// Tests that all of our configured paths exist
 				for ( var routePrefix in apiPrefixes ) {
 					for ( var route in cbRoutes ) {
 						if ( left( route.pattern, len( routePrefix ) ) == routePrefix ) {
 							var translatedPath = swaggerUtil.translatePath( route.pattern );
 							if ( !len( route.moduleRouting ) ) {
-								if ( translatedPath == "/api/v1/noCbSwagger2" ) {
-									// nothing
-									// this could handled more programmatically, but what we are saying here,
-									// is that the "magic route configured to be discarded in the swagger docs is indeed discarded"
+								if ( structKeyExists(requireTheseRoutesExistWithoutDocs, translatedPath) ) {
+									expect( normalizedDoc[ "paths" ] ).notToHaveKey( translatedPath, "expected to have discarded this route from the docs" );
+									structDelete( requireTheseRoutesExistWithoutDocs, translatedPath )
 								}
 								else {
 									expect( normalizedDoc[ "paths" ] ).toHaveKey( translatedPath );
@@ -150,6 +154,8 @@ component
 						}
 					}
 				}
+
+				expect( requireTheseRoutesExistWithoutDocs ).toBeEmpty( "all routes expected to not have docs were seen" );
 			} );
 
 			it( "Tests the API Document for module introspection", function(){

--- a/test-harness/tests/specs/RoutesParserTest.cfc
+++ b/test-harness/tests/specs/RoutesParserTest.cfc
@@ -80,6 +80,10 @@ component
 
 				expect( isJSON( APIDoc.asJSON() ) ).toBeTrue();
 
+				expect( NormalizedDoc.paths["/api/v1/noCbSwagger"] ).toHaveKey( "post", "post function NOT marked noCbSwagger" );
+				expect( NormalizedDoc.paths["/api/v1/noCbSwagger"] ).notToHaveKey( "get", "get function was marked noCbSwagger" );
+				expect( NormalizedDoc.paths ).notToHaveKey( "/api/v1/noCbSwagger2", "the lone function handling this was marked noCbSwagger" );
+
 				variables.APIDoc = APIDoc;
 			} );
 
@@ -134,7 +138,14 @@ component
 						if ( left( route.pattern, len( routePrefix ) ) == routePrefix ) {
 							var translatedPath = swaggerUtil.translatePath( route.pattern );
 							if ( !len( route.moduleRouting ) ) {
-								expect( normalizedDoc[ "paths" ] ).toHaveKey( translatedPath );
+								if ( translatedPath == "/api/v1/noCbSwagger2" ) {
+									// nothing
+									// this could handled more programmatically, but what we are saying here,
+									// is that the "magic route configured to be discarded in the swagger docs is indeed discarded"
+								}
+								else {
+									expect( normalizedDoc[ "paths" ] ).toHaveKey( translatedPath );
+								}
 							}
 						}
 					}


### PR DESCRIPTION
the presence of this attribute prevents the inclusion of the function's associated documentation from ending up in swagger docs

# Description

completes #42 

## Type of change

- [x] Improvement

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
